### PR TITLE
Add a way to include development dependencies

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -215,6 +215,11 @@ Which will be translated to:
       - conda-forge::bob>=2.3.0,<3.0.0
 
 
+If you want to include the dev-dependencies in the generated conda
+environment file, you can pass the `--dev` option to poetry2conda.  All
+the caveats and conversion patches that are described above apply to
+dev dependencies all the same.
+
 
 Contribute
 ----------

--- a/poetry2conda/convert.py
+++ b/poetry2conda/convert.py
@@ -8,7 +8,7 @@ import toml
 from poetry2conda import __version__
 
 
-def convert(file: TextIO) -> str:
+def convert(file: TextIO, include_dev=False) -> str:
     """ Convert a pyproject.toml file to a conda environment YAML
 
     This is the main function of poetry2conda, where all parsing, converting,
@@ -18,6 +18,8 @@ def convert(file: TextIO) -> str:
     ----------
     file
         A file-like object containing a pyproject.toml file.
+    include_dev
+        Whether to include the dev dependencies in the resulting environment
 
     Returns
     -------
@@ -27,6 +29,8 @@ def convert(file: TextIO) -> str:
     poetry2conda_config, poetry_config = parse_pyproject_toml(file)
     env_name = poetry2conda_config["name"]
     poetry_dependencies = poetry_config.get("dependencies", {})
+    if include_dev:
+        poetry_dependencies.update(poetry_config.get('dev-dependencies', {}))
     conda_constraints = poetry2conda_config.get("dependencies", {})
 
     dependencies, pip_dependencies = collect_dependencies(
@@ -243,10 +247,15 @@ def main():
         help="environment.yaml output file.",
     )
     parser.add_argument(
+        "--dev",
+        action="store_true",
+        help="include dev dependencies",
+    )
+    parser.add_argument(
         "--version", action="version", version=f"%(prog)s (version {__version__})"
     )
     args = parser.parse_args()
-    args.environment.write(convert(args.pyproject))
+    args.environment.write(convert(args.pyproject, include_dev=args.dev))
 
 
 if __name__ == "__main__":

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -27,6 +27,9 @@ grault = { git = "https://github.com/organization/repo.git", tag = "v2.7.4"}   #
 pizza = {extras = ["pepperoni"], version = "^1.2.3"}  # Example of a package with extra requirements
 chameleon = { git = "https://github.com/org/repo.git", tag = "v2.3" }
 
+[tool.poetry.dev-dependencies]
+fork = "^1.2"
+
 [tool.poetry2conda]
 name = "bibimbap-env"
 
@@ -61,6 +64,25 @@ dependencies:
     - git+https://github.com/organization/repo.git@v2.7.4#egg=grault
 """
 
+SAMPLE_YAML_DEV = """\
+name: bibimbap-env
+dependencies:
+  - python>=3.7.0,<4.0.0
+  - foo>=0.2.3,<0.3.0
+  - conda-forge::bar>=1.2.3,<2.0.0
+  - thud>=1.4.5,<1.5.0
+  - quux==2.34.5
+  - quuz>=3.2.0
+  - xyzzy>=2.1.0,<4.2.0
+  - pizza>=1.2.3,<2.0.0    # Note that extra requirements are not supported on conda :-(
+  - animals::lizard>=2.5.4,<3.0.0
+  - fork>=1.2.0,<2.0.0
+  - pip
+  - pip:
+    - baz>=0.4.5,<0.5.0
+    - git+https://github.com/organization/repo.git@v2.7.4#egg=grault
+"""
+
 
 def test_sample(tmpdir, mocker):
     toml_file = tmpdir / "pyproject.toml"
@@ -71,6 +93,24 @@ def test_sample(tmpdir, mocker):
     expected = yaml.safe_load(io.StringIO(SAMPLE_YAML))
 
     mocker.patch("sys.argv", ["poetry2conda", str(toml_file), str(yaml_file)])
+    main()
+
+    with yaml_file.open("r") as fd:
+        result = yaml.safe_load(fd)
+
+    assert result == expected
+
+
+def test_sample_dev(tmpdir, mocker):
+    toml_file = tmpdir / "pyproject.toml"
+    yaml_file = tmpdir / "environment.yaml"
+
+    with toml_file.open("w") as fd:
+        fd.write(SAMPLE_TOML)
+    expected = yaml.safe_load(io.StringIO(SAMPLE_YAML_DEV))
+
+    mocker.patch("sys.argv", ["poetry2conda", str(toml_file), str(yaml_file),
+                              '--dev'])
     main()
 
     with yaml_file.open("r") as fd:


### PR DESCRIPTION
I've added an option to include the development dependencies in the generated environment file.

This would be really useful for me since we want to switch a project I develop on to poetry but I would prefer to keep using conda for it.

