### PR TITLE
Add support for poetry extras

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,6 +65,13 @@ This will create a yaml file like:
       - foo>=1.2.3,<2.0.0
       # ...
 
+If you want to include extras in the created environment, you can use
+the `--extra` or `-E` arguments. They can be used multiple times to
+specify multiple extras
+
+If you also want to include development dependencies, the `--dev`
+argument will do that.
+
 Sometimes, a dependency is handled differently on conda. For this case,
 the section ``tool.poetry2conda.dependencies`` can be used to inform on specific
 channels, or package names.
@@ -213,12 +220,6 @@ Which will be translated to:
     name: strange-example
     dependencies:
       - conda-forge::bob>=2.3.0,<3.0.0
-
-
-If you want to include the dev-dependencies in the generated conda
-environment file, you can pass the `--dev` option to poetry2conda.  All
-the caveats and conversion patches that are described above apply to
-dev dependencies all the same.
 
 
 Contribute

--- a/poetry2conda/__init__.py
+++ b/poetry2conda/__init__.py
@@ -1,3 +1,3 @@
 # Note the version managed by bump2version.
 # Do not change it manually here, use bump2version to change it.
-__version__ = '0.2.0'
+__version__ = "0.2.0"

--- a/poetry2conda/convert.py
+++ b/poetry2conda/convert.py
@@ -1,6 +1,6 @@
 import argparse
 from datetime import datetime
-from typing import Mapping, TextIO, Tuple
+from typing import Mapping, TextIO, Tuple, Iterable, Optional
 
 import semantic_version
 import toml
@@ -8,7 +8,9 @@ import toml
 from poetry2conda import __version__
 
 
-def convert(file: TextIO, include_dev=False, extras=None) -> str:
+def convert(
+    file: TextIO, include_dev: bool = False, extras: Optional[Iterable[str]] = None
+) -> str:
     """ Convert a pyproject.toml file to a conda environment YAML
 
     This is the main function of poetry2conda, where all parsing, converting,
@@ -19,7 +21,10 @@ def convert(file: TextIO, include_dev=False, extras=None) -> str:
     file
         A file-like object containing a pyproject.toml file.
     include_dev
-        Whether to include the dev dependencies in the resulting environment
+        Whether to include the dev dependencies in the resulting environment.
+    extras
+        The name of extras to include in the output.  Can be None or empty
+        for no extras.
 
     Returns
     -------

--- a/poetry2conda/convert.py
+++ b/poetry2conda/convert.py
@@ -32,14 +32,14 @@ def convert(file: TextIO, include_dev=False, extras=None) -> str:
     env_name = poetry2conda_config["name"]
     poetry_dependencies = poetry_config.get("dependencies", {})
     if include_dev:
-        poetry_dependencies.update(poetry_config.get('dev-dependencies', {}))
-    poetry_extras = poetry_config.get('extras', {})
+        poetry_dependencies.update(poetry_config.get("dev-dependencies", {}))
+    poetry_extras = poetry_config.get("extras", {})
     # We mark the items listed in the selected extras as non-optional
     for extra in extras:
         for item in poetry_extras[extra]:
             dep = poetry_dependencies[item]
             if isinstance(dep, dict):
-                dep['optional'] = False
+                dep["optional"] = False
     conda_constraints = poetry2conda_config.get("dependencies", {})
 
     dependencies, pip_dependencies = collect_dependencies(
@@ -136,22 +136,22 @@ def collect_dependencies(
 
     # 1. Do a first pass to change pip to conda packages
     for name, conda_dict in conda_constraints.items():
-        if name in poetry_dependencies and 'git' in poetry_dependencies[name]:
-            poetry_dependencies[name] = conda_dict['version']
+        if name in poetry_dependencies and "git" in poetry_dependencies[name]:
+            poetry_dependencies[name] = conda_dict["version"]
 
     # 2. Now do the conversion
     for name, constraint in poetry_dependencies.items():
         if isinstance(constraint, str):
             dependencies[name] = convert_version(constraint)
         elif isinstance(constraint, dict):
-            if constraint.get('optional', False):
+            if constraint.get("optional", False):
                 continue
             if "git" in constraint:
                 git = constraint["git"]
                 tag = constraint["tag"]
                 pip_dependencies[f"git+{git}@{tag}#egg={name}"] = None
-            elif 'version' in constraint:
-                dependencies[name] = convert_version(constraint['version'])
+            elif "version" in constraint:
+                dependencies[name] = convert_version(constraint["version"])
             else:
                 raise ValueError(
                     f"This converter only supports normal dependencies and "
@@ -258,22 +258,18 @@ def main():
         help="environment.yaml output file.",
     )
     parser.add_argument(
-        "--dev",
-        action="store_true",
-        help="include dev dependencies",
+        "--dev", action="store_true", help="include dev dependencies",
     )
     parser.add_argument(
-        "--extras", "-E",
-        action='append',
-        help="Add extra requirements",
+        "--extras", "-E", action="append", help="Add extra requirements",
     )
     parser.add_argument(
         "--version", action="version", version=f"%(prog)s (version {__version__})"
     )
     args = parser.parse_args()
-    args.environment.write(convert(args.pyproject,
-                                   include_dev=args.dev,
-                                   extras=args.extras))
+    args.environment.write(
+        convert(args.pyproject, include_dev=args.dev, extras=args.extras)
+    )
 
 
 if __name__ == "__main__":

--- a/poetry2conda/convert.py
+++ b/poetry2conda/convert.py
@@ -135,6 +135,8 @@ def collect_dependencies(
         if isinstance(constraint, str):
             dependencies[name] = convert_version(constraint)
         elif isinstance(constraint, dict):
+            if constraint.get('optional', False):
+                continue
             if "git" in constraint:
                 git = constraint["git"]
                 tag = constraint["tag"]

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -132,7 +132,9 @@ def test_sample_extra(tmpdir, mocker):
         fd.write(SAMPLE_TOML)
     expected = yaml.safe_load(io.StringIO(SAMPLE_YAML_EXTRA))
 
-    mocker.patch("sys.argv", ["poetry2conda", str(toml_file), str(yaml_file), "-E", "dessert"])
+    mocker.patch(
+        "sys.argv", ["poetry2conda", str(toml_file), str(yaml_file), "-E", "dessert"]
+    )
     main()
 
     with yaml_file.open("r") as fd:
@@ -149,8 +151,7 @@ def test_sample_dev(tmpdir, mocker):
         fd.write(SAMPLE_TOML)
     expected = yaml.safe_load(io.StringIO(SAMPLE_YAML_DEV))
 
-    mocker.patch("sys.argv", ["poetry2conda", str(toml_file), str(yaml_file),
-                              '--dev'])
+    mocker.patch("sys.argv", ["poetry2conda", str(toml_file), str(yaml_file), "--dev"])
     main()
 
     with yaml_file.open("r") as fd:

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -26,6 +26,7 @@ xyzzy = ">=2.1,<4.2"        # Example of two inequalities
 grault = { git = "https://github.com/organization/repo.git", tag = "v2.7.4"}   # Example of a git package
 pizza = {extras = ["pepperoni"], version = "^1.2.3"}  # Example of a package with extra requirements
 chameleon = { git = "https://github.com/org/repo.git", tag = "v2.3" }
+pudding = { version = "^1.0", optional = true }
 
 [tool.poetry.dev-dependencies]
 fork = "^1.2"

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -28,6 +28,9 @@ pizza = {extras = ["pepperoni"], version = "^1.2.3"}  # Example of a package wit
 chameleon = { git = "https://github.com/org/repo.git", tag = "v2.3" }
 pudding = { version = "^1.0", optional = true }
 
+[tool.poetry.extras]
+dessert = ["pudding"]
+
 [tool.poetry.dev-dependencies]
 fork = "^1.2"
 
@@ -65,6 +68,25 @@ dependencies:
     - git+https://github.com/organization/repo.git@v2.7.4#egg=grault
 """
 
+SAMPLE_YAML_EXTRA = """\
+name: bibimbap-env
+dependencies:
+  - python>=3.7.0,<4.0.0
+  - foo>=0.2.3,<0.3.0
+  - conda-forge::bar>=1.2.3,<2.0.0
+  - thud>=1.4.5,<1.5.0
+  - quux==2.34.5
+  - quuz>=3.2.0
+  - xyzzy>=2.1.0,<4.2.0
+  - pizza>=1.2.3,<2.0.0    # Note that extra requirements are not supported on conda :-(
+  - animals::lizard>=2.5.4,<3.0.0
+  - pudding>=1.0.0,<2.0.0
+  - pip
+  - pip:
+    - baz>=0.4.5,<0.5.0
+    - git+https://github.com/organization/repo.git@v2.7.4#egg=grault
+"""
+
 SAMPLE_YAML_DEV = """\
 name: bibimbap-env
 dependencies:
@@ -94,6 +116,23 @@ def test_sample(tmpdir, mocker):
     expected = yaml.safe_load(io.StringIO(SAMPLE_YAML))
 
     mocker.patch("sys.argv", ["poetry2conda", str(toml_file), str(yaml_file)])
+    main()
+
+    with yaml_file.open("r") as fd:
+        result = yaml.safe_load(fd)
+
+    assert result == expected
+
+
+def test_sample_extra(tmpdir, mocker):
+    toml_file = tmpdir / "pyproject.toml"
+    yaml_file = tmpdir / "environment.yaml"
+
+    with toml_file.open("w") as fd:
+        fd.write(SAMPLE_TOML)
+    expected = yaml.safe_load(io.StringIO(SAMPLE_YAML_EXTRA))
+
+    mocker.patch("sys.argv", ["poetry2conda", str(toml_file), str(yaml_file), "-E", "dessert"])
     main()
 
     with yaml_file.open("r") as fd:


### PR DESCRIPTION
This introduces a behaviour change with regards to previous versions.  Before this optional dependencies would always be included since poetry2conda never read the optional flag.  Now they are skipped by default.

I do think the change is worth it, but I wanted to point it out.

I've also ran black on the code and included the changes it did.
