### PR TITLE
Support revs for git dependencies

### DIFF
--- a/poetry2conda/convert.py
+++ b/poetry2conda/convert.py
@@ -158,8 +158,10 @@ def collect_dependencies(
                 continue
             if "git" in constraint:
                 git = constraint["git"]
-                tag = constraint["tag"]
-                pip_dependencies[f"git+{git}@{tag}#egg={name}"] = None
+                tag = constraint.get("tag")                                                                                                                  
+                rev = constraint.get("rev")
+                tag_or_rev = tag or rev
+                pip_dependencies[f"git+{git}@{tag_or_rev}#egg={name}"] = None
             elif "version" in constraint:
                 dependencies[name] = convert_version(constraint["version"])
             else:

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -24,7 +24,8 @@ quux = "2.34.5"             # Example of an exact version
 quuz = ">=3.2"              # Example of an inequality
 xyzzy = ">=2.1,<4.2"        # Example of two inequalities
 spinach = "^19.10b0"        # Previously non-working version spec
-grault = { git = "https://github.com/organization/repo.git", tag = "v2.7.4"}   # Example of a git package
+grault = { git = "https://github.com/organization/repo.git", tag = "v2.7.4"}   # Example of a git package with a tag
+cake = { git = "https://github.com/organization/repo.git", rev = "my_branch"}   # Example of a git package with a commit/branch
 pizza = {extras = ["pepperoni"], version = "^1.2.3"}  # Example of a package with extra requirements
 chameleon = { git = "https://github.com/org/repo.git", tag = "v2.3" }
 pudding = { version = "^1.0", optional = true }
@@ -68,6 +69,7 @@ dependencies:
   - pip:
     - baz>=0.4.5,<0.5.0
     - git+https://github.com/organization/repo.git@v2.7.4#egg=grault
+    - git+https://github.com/organization/repo.git@my_branch#egg=cake
 """
 
 SAMPLE_YAML_EXTRA = """\
@@ -88,6 +90,7 @@ dependencies:
   - pip:
     - baz>=0.4.5,<0.5.0
     - git+https://github.com/organization/repo.git@v2.7.4#egg=grault
+    - git+https://github.com/organization/repo.git@my_branch#egg=cake
 """
 
 SAMPLE_YAML_DEV = """\
@@ -108,6 +111,7 @@ dependencies:
   - pip:
     - baz>=0.4.5,<0.5.0
     - git+https://github.com/organization/repo.git@v2.7.4#egg=grault
+    - git+https://github.com/organization/repo.git@my_branch#egg=cake
 """
 
 


### PR DESCRIPTION
Thank so much for putting together this tool! I've found myself in exactly the same situation you describe in the readme– I've recently joined an org that needs to manage their dependencies with poetry, but I'd like to allow folks to use conda for convenience.

In this PR, I've added support for revs (commits/branches) for git dependencies. Tags are stricter and a better practice, but I'd like to allow for more flexibility in my case (at least for now).

Poetry does allow git dependencies to now have any ref or tag, but I've stopped short of that, since that seems potentially ambiguous anyways (it's common for repos to use a `main` branch instead of a `master` branch, for instance).