### PR TITLE
feat: Add pre-commit hook.

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,8 @@
+- id: poetry2conda
+  name: poetry2conda
+  description: Convert pyproject.toml to environment.yml
+  language: python
+  entry: poetry2conda
+  files: ^pyproject.toml$
+  args: [pyproject.toml, environment.yml]
+  pass_filenames: false


### PR DESCRIPTION
Closes #24.

Testing:
- Create a `test_dir` directory tracked by `git` containing only a `pyproject.toml` file respecting the `poetry2conda` requirements (i.e. that the `[tool.poetry2conda]` section have a `name` field).
- As described in [the `pre-commit` docs](https://pre-commit.com/#developing-hooks-interactively), run
```sh
cd /path/to/test_dir
pre-commit try-repo /path/to/poetry2conda "poetry2conda" --all-files --verbose
```

The output should look something like:
```
===============================================================================
Using config:
===============================================================================
repos:
-   repo: /path/to/poetry2conda
    rev: f857af95a3e1c88492ad252e44593ce78f8881d5
    hooks:
    -   id: poetry2conda
===============================================================================
[INFO] Initializing environment for /path/to/poetry2conda.
[INFO] Installing environment for /path/to/poetry2conda.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
poetry2conda.............................................................Passed
- hook id: poetry2conda
- duration: 0.08s
```
